### PR TITLE
tiny css improvement

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,4 +1,4 @@
-.h7 img:not([role=button]):not([role=menu]) {
+.h7 img:not([role=button]):not([role=menu]):not([width]) {
   max-width: 100%;
   width: auto !important;
   height: auto !important;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "update_url":"http://clients2.google.com/service/update2/crx",
   "manifest_version": 2,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Gmail Inline Image Fit",
   "short_name": "Gmail Inline Image Fit",
   "description": "__MSG_appDesc__",


### PR DESCRIPTION
Some newsletter images still have their own width attribute on the img tag. So the css selector takes care of that.