### PR TITLE
Prevent CSS from targeting profile picture.

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,4 +1,11 @@
-.h7 img:not([role=button]):not([role=menu]) {
+/*
+ * [data-message-id] is intended to match the element that wraps an individual
+ * email reply, where it is the direct parent of the vertical split that
+ * separates the sender's profile picture from the email content. The first
+ * child of this element is the profile picture pane while the second child of
+ * this element is the rest of the email content.
+ */
+[data-message-id] > div:nth-child(2) img:not([role=button]):not([role=menu]) {
   max-width: 100%;
   width: auto !important;
   height: auto !important;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "update_url":"http://clients2.google.com/service/update2/crx",
   "manifest_version": 2,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Gmail Inline Image Fit",
   "short_name": "Gmail Inline Image Fit",
   "description": "__MSG_appDesc__",


### PR DESCRIPTION
Fixes https://github.com/igorsantos07/Gmail-Inline-Image-Fit/issues/8

I updated the CSS selector to be more specific such that it does not accidentally target the email sender's profile picture. I noticed a `data-message-id` attribute that appears to only ever appear on the element that is immediately a parent of the vertical split that separates the profile picture from the rest of the email, so I was able to specifically target the right split using a child selector and `nth-child(2)`.