### PR TITLE
fix "show details" button disappears

### DIFF
--- a/main.css
+++ b/main.css
@@ -5,7 +5,7 @@
  * child of this element is the profile picture pane while the second child of
  * this element is the rest of the email content.
  */
-[data-message-id] > div:nth-child(2) img:not([role=button]):not([role=menu]):not([width]) {
+[data-message-id] > div:nth-child(2) img:not([role=button]):not([role=menu]):not([width]):not([src="images/cleardot.gif"]) {
   max-width: 100%;
   width: auto !important;
   height: auto !important;


### PR DESCRIPTION
fixes igorsantos07#7
Ignore images/cleardot.gif because it has intrinsic size 1x1. Width attribute cannot be ignored on this element.